### PR TITLE
refactor: Simplify API by using string prompts instead of AIPrompt ob…

### DIFF
--- a/example.py
+++ b/example.py
@@ -8,13 +8,12 @@ from celeste_client.core.enums import (
     AnthropicModel,
     GeminiModel,
     HuggingFaceModel,
-    MessageRole,
     MistralModel,
     OllamaModel,
     OpenAIModel,
     Provider,
 )
-from celeste_client.core.types import AIPrompt, AIResponse
+from celeste_client.core.types import AIResponse
 
 st.set_page_config(page_title="Celeste AI", page_icon="🌟", layout="wide")
 
@@ -108,16 +107,12 @@ prompt = st.text_area(
 if st.button("✨ Generate", type="primary", use_container_width=True):
     client = create_client(selected_provider, model=selected_model)
 
-    # Create the AIPrompt
-    ai_prompt = AIPrompt(role=MessageRole.USER, content=prompt)
+    # Use the prompt directly as a string
+    ai_prompt = prompt
 
-    # Show AIPrompt details in an expander
-    with st.expander("🔍 AIPrompt Details", expanded=False):
-        # Convert role enum to its value for proper JSON display
-        prompt_dict = ai_prompt.__dict__.copy()
-        if prompt_dict.get("role"):
-            prompt_dict["role"] = prompt_dict["role"].value
-        st.json(prompt_dict)
+    # Show prompt details in an expander
+    with st.expander("🔍 Prompt Details", expanded=False):
+        st.text(ai_prompt)
 
     if streaming:
         placeholder = st.empty()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,13 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "pydantic>=2.8.2",
     "streamlit>=1.46.0",
+    "notebook>=7.4.4",
 ]
 
 [dependency-groups]
 dev = [
     "pre-commit>=4.2.0",
+    "ruff>=0.12.1",
 ]
 
 [tool.ruff]

--- a/src/celeste_client/base.py
+++ b/src/celeste_client/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Optional
 
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 
 class BaseClient(ABC):
@@ -14,13 +14,13 @@ class BaseClient(ABC):
         pass
 
     @abstractmethod
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
         """Generates a single response."""
         pass
 
     @abstractmethod
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
         """Streams the response chunk by chunk."""
         pass

--- a/src/celeste_client/providers/anthropic.py
+++ b/src/celeste_client/providers/anthropic.py
@@ -6,7 +6,7 @@ from anthropic.types import MessageParam
 from celeste_client.base import BaseClient
 from celeste_client.core.config import ANTHROPIC_API_KEY
 from celeste_client.core.enums import AnthropicModel, Provider
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 MAX_TOKENS = 1024
 
@@ -32,11 +32,11 @@ class AnthropicClient(BaseClient):
             total_tokens=usage_data.input_tokens + usage_data.output_tokens,
         )
 
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
         max_tokens = kwargs.pop("max_tokens", MAX_TOKENS)
         response = await self.client.messages.create(
             max_tokens=max_tokens,
-            messages=[MessageParam(role=prompt.role.value, content=prompt.content)],
+            messages=[MessageParam(role="user", content=prompt)],
             model=self.model_name,
             **kwargs,
         )
@@ -49,13 +49,13 @@ class AnthropicClient(BaseClient):
         )
 
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
         max_tokens = kwargs.pop("max_tokens", MAX_TOKENS)
         async with self.client.messages.stream(
             model=self.model_name,
             max_tokens=max_tokens,
-            messages=[MessageParam(role=prompt.role.value, content=prompt.content)],
+            messages=[MessageParam(role="user", content=prompt)],
             **kwargs,
         ) as stream:
             async for text in stream.text_stream:

--- a/src/celeste_client/providers/gemini.py
+++ b/src/celeste_client/providers/gemini.py
@@ -6,7 +6,7 @@ from google.genai import types
 from celeste_client.base import BaseClient
 from celeste_client.core.config import GOOGLE_API_KEY
 from celeste_client.core.enums import GeminiModel, Provider
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 
 class GeminiClient(BaseClient):
@@ -36,11 +36,11 @@ class GeminiClient(BaseClient):
             total_tokens=getattr(usage_data, "total_token_count", 0),
         )
 
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
         config = GeminiClient._get_generation_config(kwargs)
 
         response = await self.client.aio.models.generate_content(
-            model=self.model_name, contents=prompt.content, config=config
+            model=self.model_name, contents=prompt, config=config
         )
 
         # Extract usage information if available
@@ -56,13 +56,13 @@ class GeminiClient(BaseClient):
         )
 
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
         config = GeminiClient._get_generation_config(kwargs)
 
         last_usage_metadata = None
         async for chunk in await self.client.aio.models.generate_content_stream(
-            model=self.model_name, contents=prompt.content, config=config
+            model=self.model_name, contents=prompt, config=config
         ):
             if chunk.text:  # Only yield if there's actual content
                 yield AIResponse(

--- a/src/celeste_client/providers/huggingface.py
+++ b/src/celeste_client/providers/huggingface.py
@@ -5,7 +5,7 @@ from huggingface_hub import InferenceClient
 from celeste_client.base import BaseClient
 from celeste_client.core.config import HUGGINGFACE_TOKEN
 from celeste_client.core.enums import HuggingFaceModel, Provider
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 
 class HuggingFaceClient(BaseClient):
@@ -31,8 +31,8 @@ class HuggingFaceClient(BaseClient):
             total_tokens=getattr(usage_data, "total_tokens", 0),
         )
 
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
-        messages = [{"role": prompt.role.value, "content": prompt.content}]
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
+        messages = [{"role": "user", "content": prompt}]
 
         response = self.client.chat_completion(messages=messages, **kwargs)
 
@@ -44,9 +44,9 @@ class HuggingFaceClient(BaseClient):
         )
 
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
-        messages = [{"role": prompt.role.value, "content": prompt.content}]
+        messages = [{"role": "user", "content": prompt}]
 
         # Try to enable usage information like OpenAI does
         if "stream_options" not in kwargs:

--- a/src/celeste_client/providers/mistral.py
+++ b/src/celeste_client/providers/mistral.py
@@ -5,7 +5,7 @@ from mistralai import Mistral
 from celeste_client.base import BaseClient
 from celeste_client.core.config import MISTRAL_API_KEY
 from celeste_client.core.enums import MistralModel, Provider
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 
 class MistralClient(BaseClient):
@@ -27,10 +27,10 @@ class MistralClient(BaseClient):
             total_tokens=getattr(usage_data, "total_tokens", 0),
         )
 
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
         response = await self.client.chat.complete_async(
             model=self.model_name,
-            messages=[{"role": prompt.role.value, "content": prompt.content}],
+            messages=[{"role": "user", "content": prompt}],
             **kwargs,
         )
 
@@ -47,11 +47,11 @@ class MistralClient(BaseClient):
         )
 
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
         response = await self.client.chat.stream_async(
             model=self.model_name,
-            messages=[{"role": prompt.role.value, "content": prompt.content}],
+            messages=[{"role": "user", "content": prompt}],
             **kwargs,
         )
 

--- a/src/celeste_client/providers/ollama.py
+++ b/src/celeste_client/providers/ollama.py
@@ -5,7 +5,7 @@ from ollama import AsyncClient
 from celeste_client.base import BaseClient
 from celeste_client.core.config import OLLAMA_HOST
 from celeste_client.core.enums import OllamaModel, Provider
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 
 class OllamaClient(BaseClient):
@@ -26,8 +26,8 @@ class OllamaClient(BaseClient):
             total_tokens=prompt_tokens + completion_tokens,
         )
 
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
-        message = {"role": prompt.role.value, "content": prompt.content}
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
+        message = {"role": "user", "content": prompt}
         # Ensure we get usage data by setting stream=False explicitly
         if "stream" not in kwargs:
             kwargs["stream"] = False
@@ -47,9 +47,9 @@ class OllamaClient(BaseClient):
         )
 
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
-        message = {"role": prompt.role.value, "content": prompt.content}
+        message = {"role": "user", "content": prompt}
         stream = await self.client.chat(
             model=self.model_name, messages=[message], stream=True, **kwargs
         )

--- a/src/celeste_client/providers/openai.py
+++ b/src/celeste_client/providers/openai.py
@@ -10,7 +10,7 @@ from openai.types.chat import (
 from celeste_client.base import BaseClient
 from celeste_client.core.config import OPENAI_API_KEY
 from celeste_client.core.enums import OpenAIModel, Provider
-from celeste_client.core.types import AIPrompt, AIResponse, AIUsage
+from celeste_client.core.types import AIResponse, AIUsage
 
 
 class OpenAIClient(BaseClient):
@@ -30,9 +30,9 @@ class OpenAIClient(BaseClient):
             total_tokens=usage_data.total_tokens,
         )
 
-    async def generate_content(self, prompt: AIPrompt, **kwargs: Any) -> AIResponse:
+    async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
         messages: List[ChatCompletionMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=prompt.content)
+            ChatCompletionUserMessageParam(role="user", content=prompt)
         ]
         response = await self.client.chat.completions.create(
             messages=messages, model=self.model_name, **kwargs
@@ -48,10 +48,10 @@ class OpenAIClient(BaseClient):
         )
 
     async def stream_generate_content(
-        self, prompt: AIPrompt, **kwargs: Any
+        self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
         messages: List[ChatCompletionMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=prompt.content)
+            ChatCompletionUserMessageParam(role="user", content=prompt)
         ]
         response = await self.client.chat.completions.create(
             messages=messages,


### PR DESCRIPTION
…jects

- Changed generate_content() and stream_generate_content() to accept prompt: str
- Updated all provider implementations to use plain strings
- Removed AIPrompt dependency from base class and providers
- Updated example.py to pass strings directly
- Added ruff as dev dependency for linting

This change simplifies the API by removing the need to create AIPrompt objects for basic use cases. All providers now handle the user role internally.