### PR TITLE
Add warnings for missing API keys

### DIFF
--- a/src/celeste_client/core/config.py
+++ b/src/celeste_client/core/config.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from dotenv import load_dotenv
 
@@ -7,8 +8,23 @@ load_dotenv()
 
 # API Keys
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+if ANTHROPIC_API_KEY is None:
+    warnings.warn("ANTHROPIC_API_KEY not set", stacklevel=2)
+
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+if GOOGLE_API_KEY is None:
+    warnings.warn("GOOGLE_API_KEY not set", stacklevel=2)
+
 HUGGINGFACE_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
+if HUGGINGFACE_TOKEN is None:
+    warnings.warn("HUGGINGFACE_TOKEN not set", stacklevel=2)
+
 MISTRAL_API_KEY = os.getenv("MISTRAL_API_KEY")
+if MISTRAL_API_KEY is None:
+    warnings.warn("MISTRAL_API_KEY not set", stacklevel=2)
+
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if OPENAI_API_KEY is None:
+    warnings.warn("OPENAI_API_KEY not set", stacklevel=2)
+
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434")


### PR DESCRIPTION
## Summary
- add `warnings` import in `core/config.py`
- raise warnings when environment variables are missing with explicit stacklevel

## Testing
- `ruff check`
- `ruff format`

------
https://chatgpt.com/codex/tasks/task_e_688a4d766dd4832cb07621cc78dccd23