### PR TITLE
Update metadata fields with default_factory

### DIFF
--- a/src/celeste_client/core/types.py
+++ b/src/celeste_client/core/types.py
@@ -4,7 +4,7 @@ Core data types for agent communication.
 
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .enums import MessageRole, Provider
 
@@ -17,7 +17,7 @@ class AIPrompt(BaseModel):
     role: MessageRole
     content: str
     mcp_context: Optional[Dict[str, Any]] = None
-    metadata: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class AIUsage(BaseModel):
@@ -38,4 +38,4 @@ class AIResponse(BaseModel):
     content: Union[str, BaseModel, List[BaseModel]]
     usage: Optional[AIUsage] = None
     provider: Optional[Provider] = None
-    metadata: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
## Summary
- initialize `metadata` for `AIPrompt` and `AIResponse` using `Field(default_factory=dict)`
- import `Field` from Pydantic

## Testing
- `ruff format`

------
https://chatgpt.com/codex/tasks/task_e_688a4d95e244832cbc2df907fd70ad5b