### PR TITLE
Add Sphinx docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/api/celeste_client.core.rst
+++ b/docs/source/api/celeste_client.core.rst
@@ -1,0 +1,37 @@
+celeste\_client.core package
+============================
+
+Submodules
+----------
+
+celeste\_client.core.config module
+----------------------------------
+
+.. automodule:: celeste_client.core.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.core.enums module
+---------------------------------
+
+.. automodule:: celeste_client.core.enums
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.core.types module
+---------------------------------
+
+.. automodule:: celeste_client.core.types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: celeste_client.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/celeste_client.providers.rst
+++ b/docs/source/api/celeste_client.providers.rst
@@ -1,0 +1,61 @@
+celeste\_client.providers package
+=================================
+
+Submodules
+----------
+
+celeste\_client.providers.anthropic module
+------------------------------------------
+
+.. automodule:: celeste_client.providers.anthropic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.providers.google module
+---------------------------------------
+
+.. automodule:: celeste_client.providers.google
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.providers.huggingface module
+--------------------------------------------
+
+.. automodule:: celeste_client.providers.huggingface
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.providers.mistral module
+----------------------------------------
+
+.. automodule:: celeste_client.providers.mistral
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.providers.ollama module
+---------------------------------------
+
+.. automodule:: celeste_client.providers.ollama
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+celeste\_client.providers.openai module
+---------------------------------------
+
+.. automodule:: celeste_client.providers.openai
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: celeste_client.providers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/celeste_client.rst
+++ b/docs/source/api/celeste_client.rst
@@ -1,0 +1,30 @@
+celeste\_client package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   celeste_client.core
+   celeste_client.providers
+
+Submodules
+----------
+
+celeste\_client.base module
+---------------------------
+
+.. automodule:: celeste_client.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: celeste_client
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,0 +1,7 @@
+celeste_client
+==============
+
+.. toctree::
+   :maxdepth: 4
+
+   celeste_client

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,47 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../src"))
+
+project = "Celeste Client"
+copyright = "2025, Celeste Team"
+author = "Celeste Team"
+release = "0.1.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+]
+
+autodoc_mock_imports = [
+    "anthropic",
+    "google",
+    "google.generativeai",
+    "huggingface_hub",
+    "mistralai",
+    "ollama",
+    "openai",
+    "dotenv",
+    "python_dotenv",
+]
+
+templates_path: list[str] = ["_templates"]
+exclude_patterns: list[str] = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. Celeste Client documentation master file, created by
+   sphinx-quickstart on Wed Jul 30 17:15:01 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Celeste Client's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api/modules
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
## Summary
- set up Sphinx docs using sphinx-quickstart
- configure autodoc, napoleon, and RTD theme
- autogenerate API docs for celeste_client package

## Testing
- `make -C docs html`
- `pre-commit run --files docs/source/conf.py docs/source/index.rst`


------
https://chatgpt.com/codex/tasks/task_e_688a51ccc5e4832c9d25d4772eeab06a