### PR TITLE
Refactor: standardize model property name across all providers

### DIFF
--- a/src/celeste_client/providers/anthropic.py
+++ b/src/celeste_client/providers/anthropic.py
@@ -21,14 +21,14 @@ class AnthropicClient(BaseClient):
         response = await self.client.messages.create(
             max_tokens=max_tokens,
             messages=[MessageParam(role="user", content=prompt)],
-            model=self.model_name,
+            model=self.model,
             **kwargs,
         )
 
         return AIResponse(
             content=response.content[0].text,
             provider=Provider.ANTHROPIC,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -36,7 +36,7 @@ class AnthropicClient(BaseClient):
     ) -> AsyncIterator[AIResponse]:
         max_tokens = kwargs.pop("max_tokens", MAX_TOKENS)
         async with self.client.messages.stream(
-            model=self.model_name,
+            model=self.model,
             max_tokens=max_tokens,
             messages=[MessageParam(role="user", content=prompt)],
             **kwargs,
@@ -45,7 +45,7 @@ class AnthropicClient(BaseClient):
                 yield AIResponse(
                     content=text,
                     provider=Provider.ANTHROPIC,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )
 
             # finalize stream

--- a/src/celeste_client/providers/google.py
+++ b/src/celeste_client/providers/google.py
@@ -18,7 +18,7 @@ class GoogleClient(BaseClient):
         config = kwargs.pop("config", {})
 
         response = await self.client.aio.models.generate_content(
-            model=self.model_name,
+            model=self.model,
             contents=prompt,
             config=types.GenerateContentConfig(**config),
         )
@@ -28,7 +28,7 @@ class GoogleClient(BaseClient):
         return AIResponse(
             content=content,
             provider=Provider.GOOGLE,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -37,7 +37,7 @@ class GoogleClient(BaseClient):
         config = kwargs.pop("config", {})
 
         async for chunk in await self.client.aio.models.generate_content_stream(
-            model=self.model_name,
+            model=self.model,
             contents=prompt,
             config=types.GenerateContentConfig(**config),
         ):
@@ -45,5 +45,5 @@ class GoogleClient(BaseClient):
                 yield AIResponse(
                     content=chunk.text,
                     provider=Provider.GOOGLE,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )

--- a/src/celeste_client/providers/huggingface.py
+++ b/src/celeste_client/providers/huggingface.py
@@ -10,7 +10,7 @@ class HuggingFaceClient(BaseClient):
     def __init__(self, model: str = "google/gemma-2-2b-it", **kwargs: Any) -> None:
         super().__init__(model=model, provider=Provider.HUGGINGFACE, **kwargs)
         self.client = AsyncInferenceClient(
-            model=self.model_name,
+            model=self.model,
             token=settings.huggingface.access_token,
         )
 
@@ -18,7 +18,7 @@ class HuggingFaceClient(BaseClient):
         messages = [{"role": "user", "content": prompt}]
 
         response = await self.client.chat.completions.create(
-            model=self.model_name,
+            model=self.model,
             messages=messages,
             **kwargs,
         )
@@ -26,7 +26,7 @@ class HuggingFaceClient(BaseClient):
         return AIResponse(
             content=response.choices[0].message.content,
             provider=Provider.HUGGINGFACE,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -35,7 +35,7 @@ class HuggingFaceClient(BaseClient):
         messages = [{"role": "user", "content": prompt}]
 
         stream = await self.client.chat.completions.create(
-            model=self.model_name,
+            model=self.model,
             messages=messages,
             stream=True,
             **kwargs,
@@ -46,5 +46,5 @@ class HuggingFaceClient(BaseClient):
                 yield AIResponse(
                     content=chunk.choices[0].delta.content,
                     provider=Provider.HUGGINGFACE,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )

--- a/src/celeste_client/providers/mistral.py
+++ b/src/celeste_client/providers/mistral.py
@@ -13,7 +13,7 @@ class MistralClient(BaseClient):
 
     async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
         response = await self.client.chat.complete_async(
-            model=self.model_name,
+            model=self.model,
             messages=[{"role": "user", "content": prompt}],
             **kwargs,
         )
@@ -21,14 +21,14 @@ class MistralClient(BaseClient):
         return AIResponse(
             content=response.choices[0].message.content,
             provider=Provider.MISTRAL,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
         self, prompt: str, **kwargs: Any
     ) -> AsyncIterator[AIResponse]:
         response = await self.client.chat.stream_async(
-            model=self.model_name,
+            model=self.model,
             messages=[{"role": "user", "content": prompt}],
             **kwargs,
         )
@@ -39,5 +39,5 @@ class MistralClient(BaseClient):
                 yield AIResponse(
                     content=chunk.data.choices[0].delta.content,
                     provider=Provider.MISTRAL,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )

--- a/src/celeste_client/providers/ollama.py
+++ b/src/celeste_client/providers/ollama.py
@@ -15,13 +15,13 @@ class OllamaClient(BaseClient):
         message = {"role": "user", "content": prompt}
 
         response = await self.client.chat(
-            model=self.model_name, messages=[message], **kwargs
+            model=self.model, messages=[message], **kwargs
         )
 
         return AIResponse(
             content=response["message"]["content"],
             provider=Provider.OLLAMA,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -29,14 +29,14 @@ class OllamaClient(BaseClient):
     ) -> AsyncIterator[AIResponse]:
         message = {"role": "user", "content": prompt}
         stream = await self.client.chat(
-            model=self.model_name, messages=[message], stream=True, **kwargs
+            model=self.model, messages=[message], stream=True, **kwargs
         )
         async for chunk in stream:
             if not chunk.get("done"):
                 yield AIResponse(
                     content=chunk["message"]["content"],
                     provider=Provider.OLLAMA,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )
             else:
                 break

--- a/src/celeste_client/providers/openai.py
+++ b/src/celeste_client/providers/openai.py
@@ -22,7 +22,7 @@ class OpenAIClient(BaseClient):
         ]
 
         response = await self.client.chat.completions.create(
-            messages=messages, model=self.model_name, **kwargs
+            messages=messages, model=self.model, **kwargs
         )
 
         content = response.choices[0].message.content or ""
@@ -30,7 +30,7 @@ class OpenAIClient(BaseClient):
         return AIResponse(
             content=content,
             provider=Provider.OPENAI,
-            metadata={"model": self.model_name},
+            metadata={"model": self.model},
         )
 
     async def stream_generate_content(
@@ -42,7 +42,7 @@ class OpenAIClient(BaseClient):
 
         response = await self.client.chat.completions.create(
             messages=messages,
-            model=self.model_name,
+            model=self.model,
             stream=True,
             stream_options=ChatCompletionStreamOptionsParam(include_usage=False),
             **kwargs,
@@ -53,5 +53,5 @@ class OpenAIClient(BaseClient):
                 yield AIResponse(
                     content=chunk.choices[0].delta.content,
                     provider=Provider.OPENAI,
-                    metadata={"model": self.model_name, "is_stream_chunk": True},
+                    metadata={"model": self.model, "is_stream_chunk": True},
                 )


### PR DESCRIPTION
## Summary
• Replace `model_name` with `model` property across all provider classes for consistency
• Update AnthropicClient, GoogleClient, HuggingFaceClient, MistralClient, OllamaClient, OpenAIClient
• Fix TransformersClient by renaming model object to `pretrained_model` to avoid type conflicts

## Test plan
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] Run existing test suite to ensure no regressions
- [ ] Verify all providers still function correctly with the renamed property

🤖 Generated with [Claude Code](https://claude.ai/code)