### PR TITLE
Use parsed response when Google config provided

### DIFF
--- a/src/celeste_client/providers/google.py
+++ b/src/celeste_client/providers/google.py
@@ -14,15 +14,15 @@ class GoogleClient(BaseClient):
         self.client = genai.Client(api_key=settings.google.api_key)
 
     async def generate_content(self, prompt: str, **kwargs: Any) -> AIResponse:
-        config = kwargs.pop("config", {})
+        config = kwargs.pop("config", None)
 
         response = await self.client.aio.models.generate_content(
             model=self.model,
             contents=prompt,
-            config=types.GenerateContentConfig(**config),
+            config=types.GenerateContentConfig(**(config or {})),
         )
 
-        content = response.text
+        content = response.parsed if config else response.text
 
         return AIResponse(
             content=content,


### PR DESCRIPTION
## Summary
- Return `response.parsed` for Google client when `config` is supplied

## Testing
- `pre-commit run --files src/celeste_client/providers/google.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c02f8b9d38832cb193d431d5c987d8