### PR TITLE
Make local model dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ uv sync
 ```
 </details>
 
+### Optional local model support
+
+Install the lightweight client for API providers only:
+
+```bash
+pip install celeste-client
+```
+
+Add local Transformers-based model support when needed:
+
+```bash
+pip install "celeste-client[local]"
+```
+
+The `local` extra pulls in `torch`, `transformers`, and related dependencies only when you explicitly request them, keeping API focused deployments slim.
+
 <details>
 <summary><b>Using uv pip</b></summary>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,19 @@ dependencies = [
     "celeste-core>=0.1.0",
     "anthropic>=0.55.0",
     "google-genai>=0.1.0",
-    "huggingface-hub>=0.28.2",
     "mistralai>=1.8.2",
     "ollama>=0.4.6",
     "openai>=1.91.0",
     "pydantic>=2.8.2",
-    "transformers>=4.43.4",
-    "torch>=2.3.0",
+    "huggingface-hub>=0.28.2",
+]
+
+[project.optional-dependencies]
+local = [
     "accelerate>=0.33.0",
+    "torch>=2.3.0",
+    "transformers>=4.43.4",
+    "huggingface-hub>=0.28.2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- move torch, transformers, and accelerate into a new `local` optional dependency group
- guard transformer client creation with a helpful error when optional packages are missing
- document the lightweight installation and local extra in the README

## Testing
- not run (celeste-core dependency is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da8c987ea8832c8492d34c332071ee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves local model packages to a `local` extra, adds a helpful runtime error for missing optional modules, and updates README installation docs.
> 
> - **Dependencies**
>   - Introduces optional extra `local` in `pyproject.toml`; moves `accelerate`, `torch`, and `transformers` (and keeps `huggingface-hub`) under this extra, removing them from core deps.
> - **Client initialization** (`src/celeste_client/__init__.py`)
>   - Adds `OPTIONAL_PROVIDER_EXTRAS` mapping for `Provider.TRANSFORMERS`.
>   - Wraps dynamic import to surface a clear `ModuleNotFoundError` instructing `pip install celeste-client[local]` when optional modules are missing.
> - **Docs** (`README.md`)
>   - Adds instructions for lightweight install (`pip install celeste-client`) and optional local model support via `pip install "celeste-client[local]"`; explains purpose of the `local` extra.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 981a0cde3b8b83dacafa9684a2eefce917ac663e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->